### PR TITLE
allow setAgingRegValue to return success

### DIFF
--- a/Himadri_DS3231.cpp
+++ b/Himadri_DS3231.cpp
@@ -1830,4 +1830,5 @@ boolean Himadri_DS3231::setAgingRegValue(int8_t val) {
   } else {
     return false;
   }
+  return true;
 };

--- a/Himadri_DS3231.cpp
+++ b/Himadri_DS3231.cpp
@@ -26,7 +26,7 @@ This library implements the following features:
      and meridian OR Alarm2 matching for exact minutes / hour with time format
      and meridian
   10. Set Alarm1 matching seconds and minutes
-  11. Set Alaram1 matching seconds, minutes and hour
+  11. Set Alarm1 matching seconds, minutes and hour
       OR Alarm2 matching minutes and hour
   12. Set Alarm1 matching day / date with hour, minutes and seconds
       OR Alarm2 matching day / date with hour, minutes
@@ -896,7 +896,7 @@ boolean Himadri_DS3231::readDateTime(struct timeParameters* timeVals) {
 };
 
 /**
-  Set Alaram on every period of Seconds / Minutes / Hour
+  Set Alarm on every period of Seconds / Minutes / Hour
 **/
 boolean Himadri_DS3231::setAlarm(uint8_t periodicity, uint8_t alarm) {
   Wire.beginTransmission(DS3231_ADDRESS);
@@ -1202,7 +1202,7 @@ boolean Himadri_DS3231::setAlarm(uint8_t ss, uint8_t mm, uint8_t alarm) {
 };
 
 /**
-  Set Alaram matching seconds, minutes and hour
+  Set Alarm matching seconds, minutes and hour
 */
 boolean Himadri_DS3231::setAlarm(uint8_t ss, uint8_t mm, uint8_t hh, boolean tf, boolean md, uint8_t alarm) {
   Wire.beginTransmission(DS3231_ADDRESS);
@@ -1304,7 +1304,7 @@ boolean Himadri_DS3231::setAlarm(uint8_t ss, uint8_t mm, uint8_t hh, boolean tf,
 };
 
 /**
-  Set Alaram matching seconds, minutes and hour
+  Set Alarm matching seconds, minutes and hour
 **/
 boolean Himadri_DS3231::setAlarm(uint8_t ss, uint8_t mm, uint8_t hh,
   uint8_t dyDt, boolean dy, boolean tf, boolean md, uint8_t alarm) {

--- a/Himadri_DS3231.cpp
+++ b/Himadri_DS3231.cpp
@@ -1804,16 +1804,16 @@ boolean Himadri_DS3231::bsyStatus() {
 /**
   Get Aging Register value
 **/
-uint8_t Himadri_DS3231::agingRegValue() {
+int8_t Himadri_DS3231::agingRegValue() {
   uint8_t agingReg = readRegister(DS3231_AGING_REG);
 
   if ((agingReg & 0x80) != 0) {                 // 10000000
     agingReg ^= 0xFF;                           // 11111111
     agingReg  += 0x1;                           // 00000001
-    agingReg = agingReg * -1;
+    return (int8_t) agingReg * -1;
   }
 
-  return agingReg;
+  return (int8_t) agingReg;
 };
 
 /**
@@ -1830,5 +1830,6 @@ boolean Himadri_DS3231::setAgingRegValue(int8_t val) {
   } else {
     return false;
   }
+
   return true;
 };

--- a/Himadri_DS3231.h
+++ b/Himadri_DS3231.h
@@ -26,7 +26,7 @@ This library implements the following features:
      and meridian OR Alarm2 matching for exact minutes / hour with time format
      and meridian
   10. Set Alarm1 matching seconds and minutes
-  11. Set Alaram1 matching seconds, minutes and hour
+  11. Set Alarm1 matching seconds, minutes and hour
       OR Alarm2 matching minutes and hour
   12. Set Alarm1 matching day / date with hour, minutes and seconds
       OR Alarm2 matching day / date with hour, minutes
@@ -117,7 +117,7 @@ This library implements the following features:
   #define DS3231_YEAR_REG             0x06    // Year Register
 
   // Alarm1 Register
-  #define DS3231_AL1SEC_REG           0x07    // Alaram1 Seconds Register
+  #define DS3231_AL1SEC_REG           0x07    // Alarm1 Seconds Register
   #define DS3231_AL1MIN_REG           0x08    // Alarm1 Minutes Register
   #define DS3231_AL1HOUR_REG          0x09    // Alarm1 Hour Register
   #define DS3231_AL1WDAY_REG          0x0A    // Alarm1 Day Register
@@ -401,7 +401,7 @@ This library implements the following features:
       boolean readDateTime(struct timeParameters* timeVals);
 
       /**
-        Set Alaram on every period of Seconds / Minutes / Hour
+        Set Alarm on every period of Seconds / Minutes / Hour
 
         @param periodicity Choice value of unsigned integer of setting the Alarm
         @param alarm Alarm choice unsigned integer value. It can be Alarm1 / Alarm2
@@ -432,7 +432,7 @@ This library implements the following features:
       boolean setAlarm(uint8_t ss, uint8_t mm, uint8_t alarm);
 
       /**
-        Set Alaram matching seconds, minutes and hour
+        Set Alarm matching seconds, minutes and hour
 
         @param ss Unsigned integer value for Seconds
         @param mm Unsigned integer value for Minutes
@@ -445,7 +445,7 @@ This library implements the following features:
       boolean setAlarm(uint8_t ss, uint8_t mm, uint8_t hh, boolean tf, boolean md, uint8_t alarm);
 
       /**
-        Set Alaram matching seconds, minutes and hour
+        Set Alarm matching seconds, minutes and hour
 
         @param ss Unsigned integer value for Seconds
         @param mm Unsigned integer value for Minutes

--- a/Himadri_DS3231.h
+++ b/Himadri_DS3231.h
@@ -610,7 +610,7 @@ This library implements the following features:
 
         @return Return the value of Aging Register
       */
-      uint8_t agingRegValue(void);
+      int8_t agingRegValue(void);
 
       /**
         Set Aging Register value, it takes user-provided value to add to or


### PR DESCRIPTION
setAgingRegValue() is supposed to return true on success, but there is only a return false in case the val parameter is out of bounds. There is no return value given if setting the register is successful, so it too returns false. This adds return true for success.